### PR TITLE
Make use of /usr/sbin/ebslvm

### DIFF
--- a/build/config/mount_spade_volumes.conf
+++ b/build/config/mount_spade_volumes.conf
@@ -1,0 +1,10 @@
+# upstart file to mount volume
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+script
+  /usr/sbin/ebslvm vgebs lvebs /mnt
+  ln -sFTf /mnt /opt/science/spade/data
+  emit mounted
+end script

--- a/build/config/spade.conf
+++ b/build/config/spade.conf
@@ -1,6 +1,6 @@
 # upstart file to run spade
 
-start on runlevel [2345]
+start on mounted
 stop on starting rc RUNLEVEL=[016]
 
 respawn

--- a/build/finalize.sh
+++ b/build/finalize.sh
@@ -10,4 +10,5 @@ PKGDIR="/tmp/pkg"
 mv ${PKGDIR}/deploy ${SPADEDIR}
 
 # Setup upstart
+mv ${CONFDIR}/mount_spade_volumes.conf ${UPSTARTDIR}/mount_spade_volumes.conf
 mv ${CONFDIR}/spade.conf ${UPSTARTDIR}/spade.conf

--- a/build/scripts/run_spade.sh
+++ b/build/scripts/run_spade.sh
@@ -3,9 +3,6 @@ set -e -u -o pipefail
 
 SPADE_DIR="/opt/science/spade"
 
-/usr/sbin/ebslvm vgebs lvebs /mnt
-ln -s /mnt ${SPADE_DIR}/data
-
 export GOMAXPROCS="3" # we need 3 or more for spade to run well..
 
 export GEO_IP_DB="${SPADE_DIR}/config/GeoLiteCity.dat"


### PR DESCRIPTION
The new baseami provides /usr/sbin/ebslvm which we use
here to mount ebs volumes in an lvm in /mnt, that means
we no longer provide the symlink during the build phase
