### PR TITLE
Fix incorrect use of signals in upstart

### DIFF
--- a/build/config.json
+++ b/build/config.json
@@ -1,7 +1,7 @@
 {
   "name": "spade",
   "creds": "~/.aws",
-  "baseami": "ami-55612f65",
+  "baseami": "ami-9b1158ab",
   "stages": {
     "build": "./build/gobuild.sh",
     "test": "./build/gotest.sh",

--- a/build/config/mount_spade_volumes.conf
+++ b/build/config/mount_spade_volumes.conf
@@ -1,10 +1,11 @@
 # upstart file to mount volume
 
-start on runlevel [2345]
-stop on runlevel [016]
+start on filesystem
+
+emits ebslvm-mounted
 
 script
-  /usr/sbin/ebslvm vgebs lvebs /mnt
   ln -sFTf /mnt /opt/science/spade/data
-  emit mounted
+  /usr/sbin/ebslvm vgebs lvebs /mnt
+  initctl emit ebslvm-mounted
 end script

--- a/build/config/spade.conf
+++ b/build/config/spade.conf
@@ -1,7 +1,9 @@
 # upstart file to run spade
 
-start on mounted
+start on ebslvm-mounted
 stop on starting rc RUNLEVEL=[016]
+
+emits spade-running
 
 respawn
 respawn limit 10 5
@@ -11,5 +13,5 @@ kill signal SIGINT
 
 script
   exec /opt/science/spade/bin/run_spade.sh
-  emit spade_running
+  initctl emit spade-running
 end script


### PR DESCRIPTION
FAO: @crxpandion 

[Mounted is an established signal](http://upstart.ubuntu.com/cookbook/#mounted) which results in two things:
- we were triggering it needlessly
- we were not filtering it in our `spade.conf` and as a result were starting spade prior to `/mnt` being mounted

This commit fixes these things, the former is benign, the latter was resulting in us still writing to the root partition, which should be fixed now as we establish the symlink and then trigger the formatting/mounting, which in turn will trigger the `mounted` event with `MOUNTPOINT` set to `/mnt`, which we then use to start spade.
