### PR TITLE
transformer passes new tests

### DIFF
--- a/transformer/redshift_types.go
+++ b/transformer/redshift_types.go
@@ -233,10 +233,18 @@ func varcharFormat(target interface{}) (string, error) {
 
 func boolFormat(target interface{}) (string, error) {
 	b, ok := target.(bool)
-	if !ok {
-		return "", genError(target, "bool")
+	if ok {
+		return fmt.Sprintf("%t", b), nil
+	} // else we should try parsing it as a number
+	i, ok := target.(json.Number)
+	if ok {
+		if i == json.Number("1") {
+			return "true", nil
+		} else if i == json.Number("0") {
+			return "false", nil
+		}
 	}
-	return fmt.Sprintf("%t", b), nil
+	return "", genError(target, "Bool")
 }
 
 func ipCityFormat(target interface{}) (string, error) {

--- a/transformer/redshift_types_test.go
+++ b/transformer/redshift_types_test.go
@@ -78,6 +78,10 @@ func TestBooleanConversion(t *testing.T) {
 	_type_runner(t, true, booleanConverter, "true", false)
 	_type_runner(t, "true", booleanConverter, "", true)
 	_type_runner(t, "asd", booleanConverter, "", true)
+	_type_runner(t, json.Number("1"), booleanConverter, "true", false)
+	_type_runner(t, json.Number("0"), booleanConverter, "false", false)
+	_type_runner(t, "1", booleanConverter, "true", true)
+	_type_runner(t, "0", booleanConverter, "false", true)
 }
 
 func TestIpConversion(t *testing.T) {


### PR DESCRIPTION
Mixpanel's iOS lib now sends 1 and 0 rather than true and false :/, which breaks json conventions. We've been dropping all booleans sent from iOS for months.